### PR TITLE
Doc: How to use with a GUI editor

### DIFF
--- a/README.md
+++ b/README.md
@@ -129,6 +129,11 @@ The editor command is set when the server is launched.  Use one of...
     export TEXT_AID_TOO_EDITOR="urxvt -T textaid -geometry 100x30+80+20 -e vim"
     text-aid-too
 
+Example of usage with a GUI editor:
+
+    export TEXT_AID_TOO_EDITOR="bash -c 'pantheon-terminal -e \"nvim $1\"' --"
+    text-aid-too
+
 The command line takes priority.
 
 ### Port


### PR DESCRIPTION
Since the `%s` feature was removed, it is particularly difficult to find the right command to launch an editor with a graphical user interface (for instance, Neovim inside a terminal emulator).

This commit adds an example that users can use as-is or use as a base for their custom command.