### PR TITLE
Fix systematic crash since Node.js 10

### DIFF
--- a/server/server.coffee
+++ b/server/server.coffee
@@ -135,7 +135,7 @@ handler = (ws) -> (message) ->
 
       fs.writeFile filename, (request.originalText ? request.text), (error) ->
         return exit() if error
-        onExit.push -> fs.unlink filename
+        onExit.push -> fs.unlink filename, ->
 
         sendText = (continuation = null) ->
           fs.readFile filename, "utf8", (error, data) ->


### PR DESCRIPTION
The usage of `fs.unlink()` without a callback is deprecated since
Node.js 7, and throws a `TypeError` since Node.js 10 \[1].

Closes #9 and #15.

\[1]: https://nodejs.org/api/fs.html#fs_fs_unlink_path_callback